### PR TITLE
Fix #4 (part 1) - extract path from resource string before searching routes

### DIFF
--- a/src/route/handlers/router.cr
+++ b/src/route/handlers/router.cr
@@ -18,9 +18,9 @@ module Route
       method = context.request.method
       path = case md = %r(^[^?]+).match(context.request.resource)
              when Regex::MatchData
-                md[0]
+               md[0]
              else
-                context.request.resource
+               context.request.resource
              end
 
       route = @tree.find(method.upcase + path)

--- a/src/route/handlers/router.cr
+++ b/src/route/handlers/router.cr
@@ -16,7 +16,12 @@ module Route
 
     def search_route(context : HTTP::Server::Context) : RouteContext?
       method = context.request.method
-      path = context.request.resource
+      path = case md = %r(^[^?]+).match(context.request.resource)
+             when Regex::MatchData
+                md[0]
+             else
+                context.request.resource
+             end
 
       route = @tree.find(method.upcase + path)
 


### PR DESCRIPTION
This change extracts the "/path" from "/path?params" and uses that as the routing "key"

Fixes: #4 