### PR TITLE
Fix #4 (optional part 2): merge context.request.query_params in to route.params

### DIFF
--- a/src/route/handlers/router.cr
+++ b/src/route/handlers/router.cr
@@ -20,6 +20,13 @@ module Route
 
       route = @tree.find(method.upcase + path)
 
+      # merge query params in to route params for 'convenience'
+      # XXX can't merge these with + since Radix params are String=>String 
+      #     and route params are a distinct thing.
+      context.request.query_params.each do |k, v|
+        route.params[k] = v
+      end
+
       if route.found?
         return RouteContext.new(route.payload, route.params)
       end

--- a/src/route/handlers/router.cr
+++ b/src/route/handlers/router.cr
@@ -24,7 +24,7 @@ module Route
       # XXX can't merge these with + since Radix params are String=>String 
       #     and route params are a distinct thing.
       context.request.query_params.each do |k, v|
-        route.params[k] = v
+        route.params[k] = v unless route.params.has_key?(k)
       end
 
       if route.found?


### PR DESCRIPTION
Merges `context.request.query_params` in to `route.params` (taking care not to replace preexisting items, as a separate commit in this changeset you can exclude if you would prefer overwriting)