### PR TITLE
Speedup path lookup by avoiding object allocation

### DIFF
--- a/src/route/handlers/router.cr
+++ b/src/route/handlers/router.cr
@@ -16,14 +16,7 @@ module Route
 
     def search_route(context : HTTP::Server::Context) : RouteContext?
       method = context.request.method
-      path = case md = %r(^[^?]+).match(context.request.resource)
-             when Regex::MatchData
-               md[0]
-             else
-               context.request.resource
-             end
-
-      route = @tree.find(method.upcase + path)
+      route = @tree.find(method.upcase + context.request.path)
 
       # Merge query params into path params
       context.request.query_params.each do |k, v|


### PR DESCRIPTION
`Request#resource` relies on `URI#full_path` to combine both `path` and `query` elements of the parsed URI in order to construct another string.

By doing that, a few temporary strings are allocated, adding elements for the GC to collect.

That combined with the Regex introduces a slowdown in the lookup, not to mention the call to PCRE (C land).

`URI` already provides `path` clean from query parameters and that is exposed as part of the request as `path`.

You can see the performance differences on the following benchmark:

https://gist.github.com/luislavena/2bbb6befb8c0dd5ea3c7a628aba3d39d

Results:

```
             URI#path: 423.36M (  2.36ns) (± 1.61%)        fastest
URI#full_path + Regex:   3.44M ( 290.8ns) (± 0.51%) 123.11× slower
```

Thank you. :heart: :heart: :heart: 