### PR TITLE
Use String.build to format_data in profile

### DIFF
--- a/src/route/handlers/profiler.cr
+++ b/src/route/handlers/profiler.cr
@@ -19,17 +19,15 @@ module Route
     @data = {} of String => Access
 
     def format_data : String
-      res = ""
-
-      @data.each do |key, access|
-        res += "[ #{access.method} #{access.path} ] ".ljust(20, ' ')
-        res += "Access: #{access.n} ".ljust(20, ' ')
-        res += "Total: #{format_time(access.time)} ".ljust(20, ' ')
-        res += "Ave: #{format_time(access.time/access.n)} ".ljust(20, ' ')
-        res += "\n"
+      String.build do |res|
+        @data.each do |key, access|
+          res << "[ #{access.method} #{access.path} ] ".ljust(20, ' ')
+          res << "Access: #{access.n} ".ljust(20, ' ')
+          res << "Total: #{format_time(access.time)} ".ljust(20, ' ')
+          res << "Ave: #{format_time(access.time/access.n)} ".ljust(20, ' ')
+          res << "\n"
+        end
       end
-
-      res
     end
 
     def call(context)


### PR DESCRIPTION
[String.build](https://crystal-lang.org/api/0.21.1/String.html#build%28capacity%3D64%2C%26block%29%3Aself-class-method) is a de-facto string builder in Crystal. Much more faster than the default string concatenation:

```crystal
require "benchmark"

def concatenate
  res = ""
  1000.times do |i|
    res += "#{i}"
  end
end

def build
  String.build do |res|
    1000.times do |i|
      res << "#{i}"
    end
  end
end

Benchmark.ips do |x|
  x.report("concatenate") { concatenate }
  x.report("build") { build }
end
```

```sh
$ crystal string_concatenation.cr --release
concatenate 631.46  (  1.58ms) (± 2.02%)  8.28× slower
      build   5.23k (191.17µs) (± 1.24%)       fastest
```