### PR TITLE
add leading / to Radix::Tree

### DIFF
--- a/src/router.cr
+++ b/src/router.cr
@@ -12,7 +12,7 @@ module Router
   # Define each method for supported http methods
   {% for http_method in HTTP_METHODS %}
     def {{http_method.id}}(path : String, &block : Action)
-      @route_handler.add_route("{{http_method.id.upcase}}" + path, block)
+      @route_handler.add_route("/{{http_method.id.upcase}}" + path, block)
     end
   {% end %}
 end

--- a/src/router/handler/handler.cr
+++ b/src/router/handler/handler.cr
@@ -8,9 +8,9 @@ module Router
 
     def search_route(context : HTTP::Server::Context) : RouteContext?
       method = context.request.method
-      route = @tree.find(method.upcase + context.request.path)
+      route = @tree.find("/" + method.upcase + context.request.path)
 
-      return { action: route.payload, params: route.params } if route.found?
+      return {action: route.payload, params: route.params} if route.found?
 
       nil
     end


### PR DESCRIPTION
Radix doesn’t find some paths otherwise

For example - running the following code in `crystal play`

```crystal
require "radix"

tree = Radix::Tree(Symbol).new
tree.add "GET/params/:id", :get_params
tree.add "GET/params/:id/test/:test_id", :get_test
tree.add "POST/post_test", :post_test
tree.add "PUT/put_test", :put_test
tree.add "GET/", :index

result = tree.find "PUT/put_test"

if result.found?
  puts result.payload
else
  puts "error!"  # => error!
end
```

however this code works

```crystal
require "radix"

tree = Radix::Tree(Symbol).new
tree.add "/GET/params/:id", :get_params
tree.add "/GET/params/:id/test/:test_id", :get_test
tree.add "/POST/post_test", :post_test
tree.add "/PUT/put_test", :put_test
tree.add "/GET/", :index

result = tree.find "/PUT/put_test"

if result.found?
  puts result.payload  # => put_test
else
  puts "error!"
end
```
