### PR TITLE
Adding default methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Define a method to draw all routes for your web server.
 class WebServer
   include Router
 
-  def draw_routes
+  def draw
     # Drawing routes HERE!
   end
 end
@@ -54,7 +54,7 @@ In that method, call HTTP method name (downcase) like `get` or `post` with PATH 
 class WebServer
   include Router
 
-  def draw_routes
+  def draw
     get "/" do |context, params|
       context.response.print "Hello router.cr!"
       context
@@ -69,7 +69,7 @@ To activate (run) the route, just define run methods for your server with route_
 class WebServer
   include Router
 
-  def draw_routes
+  def draw
     get "/" do |context, params|
       context.response.print "Hello router.cr!"
       context
@@ -93,7 +93,7 @@ See [sample](https://github.com/tbrand/router.cr/blob/master/sample/sample.cr) a
 class WebServer
   include Router
 
-  def draw_routes
+  def draw
     get "/user/:id" do |context, params|
       context.response.print params["id"] # get :id in url from params
       context

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Define a method to draw all routes for your web server.
 ```crystal
 class WebServer
   include Router
-  
+
   def draw_routes
     # Drawing routes HERE!
   end
@@ -68,17 +68,12 @@ To activate (run) the route, just define run methods for your server with route_
 ```crystal
 class WebServer
   include Router
-  
+
   def draw_routes
     get "/" do |context, params|
       context.response.print "Hello router.cr!"
       context
     end
-  end
-  
-  def run
-    server = HTTP::Server.new(3000, route_handler)
-    server.listen
   end
 end
 ```
@@ -86,9 +81,7 @@ Here route_handler is getter defined in Router. So you can call `route_handler` 
 
 Finally, run your server.
 ```crystal
-web_server = WebServer.new
-web_server.draw_routes
-web_server.run
+web_server = WebServer.new.run 3000
 ```
 
 See [sample](https://github.com/tbrand/router.cr/blob/master/sample/sample.cr) and [tips]([sample](https://github.com/tbrand/router.cr/blob/master/sample/tips.cr)) for details.

--- a/sample/sample.cr
+++ b/sample/sample.cr
@@ -9,7 +9,7 @@ struct WebServer
   # GET  "/"
   # GET  "/user/:id"
   # POST "/user"
-  def draw_routes
+  def draw
     # Define index access for this server
     # We just print a result "Hello router.cr!" here
     get "/" do |context, params|

--- a/sample/sample.cr
+++ b/sample/sample.cr
@@ -1,11 +1,8 @@
 require "../src/router"
 
-class WebServer
+struct WebServer
   # Add Router functions to WebServer
   include Router
-
-  def initialize
-  end
 
   # Define a method to draw routes of your server
   # Here we define
@@ -43,12 +40,7 @@ class WebServer
   # Running this server on port 3000
   # router_handler getter of RouteHandler
   # that's defined in Router module
-  def run
-    server = HTTP::Server.new(3000, route_handler)
-    server.listen
-  end
+
 end
 
-web_server = WebServer.new
-web_server.draw_routes
-web_server.run
+WebServer.new.run 3000

--- a/sample/tips.cr
+++ b/sample/tips.cr
@@ -15,7 +15,7 @@ require "../src/router"
 struct WebServer
   include Router
 
-  def draw_routes
+  def draw
     get "/" do |context, params|
       context.response.print "OK"
       context

--- a/sample/tips.cr
+++ b/sample/tips.cr
@@ -12,16 +12,8 @@ require "../src/router"
 # - HTTP::StaticFileHandler         https://crystal-lang.org/api/HTTP/StaticFileHandler.html
 # - HTTP::WebSocketHandler          https://crystal-lang.org/api/HTTP/WebSocketHandler.html
 
-class WebServer
+struct WebServer
   include Router
-
-  # HTTP::Handler(s)
-  @log_handler = HTTP::LogHandler.new(STDOUT)
-  @error_handler = HTTP::ErrorHandler.new
-  @static_file_handler = HTTP::StaticFileHandler.new(File.expand_path("../public", __FILE__))
-
-  def initialize
-  end
 
   def draw_routes
     get "/" do |context, params|
@@ -29,41 +21,28 @@ class WebServer
       context
     end
   end
-
-  def run
-    # Drawing routes for this server
-    draw_routes
-
-    # Please note about the order of the handlers.
-    # 1. LogHandler should be the first of the array
-    #    since it should get all accesses.
-    # 2. ErrorHandler should be the next of the LogHandler to handle all errors.
-    # 3. StatiFileHandler should be the next of the ErrorHandler
-    #    since it should serve static files before accesses coming to RouteHandler.
-    #    StaticFileHandler will pass the access to the RouteHandler
-    #    if the file or directory does not exist.
-    # 4. So RouteHandler should be last.
-    # 
-    # The array of the handlers should be like this.
-    # Note: if a route can't be handled by RouteHandler (a.k.a. route not found)
-    # and this handler is the last, a 404 error response will be returned;
-    # otherwise the execution will continue with the next handler in a row
-    handlers = [
-      @log_handler,
-      @error_handler,
-      @static_file_handler,
-      route_handler,
-    ]
-
-    server = HTTP::Server.new(3000, handlers)
-    server.listen
-
-    # Try
-    # `curl localhost:3000/ok`         <- Handle route
-    # `curl localhost:3000/hello.html` <- Serve static file
-    # `curl localhost:3000/invalid`    <- Internal Error(500)
-  end
 end
 
-web_server = WebServer.new
-web_server.run
+# HTTP::Handler(s)
+# Please note about the order of the handlers.
+# 1. LogHandler should be the first of the array
+#    since it should get all accesses.
+# 2. ErrorHandler should be the next of the LogHandler to handle all errors.
+# 3. StatiFileHandler should be the next of the ErrorHandler
+#    since it should serve static files before accesses coming to RouteHandler.
+#    StaticFileHandler will pass the access to the RouteHandler
+#    if the file or directory does not exist.
+# 4. So RouteHandler should be last.
+#
+# The array of the handlers should be like this.
+# Note: if a route can't be handled by RouteHandler (a.k.a. route not found)
+# and this handler is the last, a 404 error response will be returned;
+# otherwise the execution will continue with the next handler in a row
+
+web_server = WebServer.new.run(handlers: [HTTP::LogHandler.new(STDOUT),
+                                          HTTP::ErrorHandler.new,
+                                          HTTP::StaticFileHandler.new(File.expand_path("../public", __FILE__))])
+# Try
+# `curl localhost:3000/ok`         <- Handle route
+# `curl localhost:3000/hello.html` <- Serve static file
+# `curl localhost:3000/invalid`    <- Internal Error(500)

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: router
-version: 0.1.13
+version: 0.3.0
 
 authors:
   - Taichiro Suzuki <taichiro0709@gmail.com>

--- a/spec/mock_server.cr
+++ b/spec/mock_server.cr
@@ -1,10 +1,7 @@
 require "../src/router"
 
-class MockServer
+struct MockServer
   include Router
-
-  @server : HTTP::Server?
-  @route_handler = RouteHandler.new
 
   def draw_routes
     get "/" do |context, params|
@@ -30,21 +27,6 @@ class MockServer
     put "/put_test" do |context, params|
       context.response.print "ok"
       context
-    end
-  end
-
-  def initialize(@port : Int32)
-  end
-
-  def run
-    draw_routes
-
-    @server = HTTP::Server.new(@port, [route_handler]).listen
-  end
-
-  def close
-    if server = @server
-      server.close
     end
   end
 end

--- a/spec/mock_server.cr
+++ b/spec/mock_server.cr
@@ -3,7 +3,7 @@ require "../src/router"
 struct MockServer
   include Router
 
-  def draw_routes
+  def draw
     get "/" do |context, params|
       context.response.print "index"
       context

--- a/spec/route_spec.cr
+++ b/spec/route_spec.cr
@@ -3,10 +3,10 @@ require "./mock_server"
 require "./curl"
 
 describe Router do
-  mock_server = MockServer.new(3000)
+  mock_server = MockServer.new
 
   spawn do
-    mock_server.run
+    mock_server.run 3000
   end
 
   sleep 0.5

--- a/src/router.cr
+++ b/src/router.cr
@@ -17,18 +17,21 @@ module Router
     end
   {% end %}
 
+  def draw
+  end
+
   def run(port : Int32 = 3000)
-    draw_routes
+    draw
     @server = HTTP::Server.new(port, [@route_handler]).listen
   end
 
   def run(host : String = "127.0.0.1", port : Int32 = 3000)
-    draw_routes
+    draw
     @server = HTTP::Server.new(host, port, [@route_handler]).listen
   end
 
   def run(host : String = "127.0.0.1", port : Int32 = 3000, handlers : Array(HTTP::Handler) = Array(HTTP::Handler))
-    draw_routes
+    draw
     @server = HTTP::Server.new(host, port, handlers + [@route_handler]).listen
   end
 

--- a/src/router.cr
+++ b/src/router.cr
@@ -6,6 +6,7 @@ module Router
   alias RouteContext = NamedTuple(action: Action, params: Hash(String, String))
 
   getter route_handler : RouteHandler = RouteHandler.new
+  @server : HTTP::Server?
 
   HTTP_METHODS = %w(get post put patch delete options)
 
@@ -15,4 +16,25 @@ module Router
       @route_handler.add_route("/{{http_method.id.upcase}}" + path, block)
     end
   {% end %}
+
+  def run(port : Int32 = 3000)
+    draw_routes
+    @server = HTTP::Server.new(port, [@route_handler]).listen
+  end
+
+  def run(host : String = "127.0.0.1", port : Int32 = 3000)
+    draw_routes
+    @server = HTTP::Server.new(host, port, [@route_handler]).listen
+  end
+
+  def run(host : String = "127.0.0.1", port : Int32 = 3000, handlers : Array(HTTP::Handler) = Array(HTTP::Handler))
+    draw_routes
+    @server = HTTP::Server.new(host, port, handlers + [@route_handler]).listen
+  end
+
+  def close
+    if server = @server
+      server.close
+    end
+  end
 end

--- a/src/router/handler/handler.cr
+++ b/src/router/handler/handler.cr
@@ -1,30 +1,25 @@
-module Router
-  class RouteHandler
-    include HTTP::Handler
+class Router::RouteHandler
+  include HTTP::Handler
 
-    def initialize
-      @tree = Radix::Tree(Action).new
+  def initialize
+    @tree = Radix::Tree(Action).new
+  end
+
+  def search_route(context : HTTP::Server::Context) : RouteContext?
+    route = @tree.find('/' + context.request.method.upcase + context.request.path)
+    return {action: route.payload, params: route.params} if route.found?
+    nil
+  end
+
+  def call(context : HTTP::Server::Context)
+    if route_context = search_route(context)
+      route_context[:action].call(context, route_context[:params])
+    else
+      call_next(context)
     end
+  end
 
-    def search_route(context : HTTP::Server::Context) : RouteContext?
-      method = context.request.method
-      route = @tree.find("/" + method.upcase + context.request.path)
-
-      return {action: route.payload, params: route.params} if route.found?
-
-      nil
-    end
-
-    def call(context : HTTP::Server::Context)
-      if route_context = search_route(context)
-        route_context[:action].call(context, route_context[:params])
-      else
-        call_next(context)
-      end
-    end
-
-    def add_route(key : String, action : Action)
-      @tree.add(key, action)
-    end
+  def add_route(key : String, action : Action)
+    @tree.add(key, action)
   end
 end


### PR DESCRIPTION
I've added default methods for `Router#run` and `Router#close` to allow us not to write them.
I've changed the name `Router#draw_routes` to `Router#routes`, because more concise/declarative to list routes.

The performance seems to be close to the same. There are also some formatting.

Side note: we can use `Struct` instead of `Class` to gain speed in some cases, I've changed the `samples` accordingly.