### PR TITLE
Greatly improve static path performance

### DIFF
--- a/src/router/handler/handler.cr
+++ b/src/router/handler/handler.cr
@@ -27,7 +27,7 @@ module Router
     end
 
     def add_route(key : String, action : Action)
-      if key.includes? ':'
+      if key.includes?(':') || key.includes?('*')
         @tree.add(key, action)
       else
         @static_routes[key] = action


### PR DESCRIPTION
Comparing luislavena/radix with a hash for static route lookup.

Radix tree with a mix of static and route params paths
<img width="542" alt="image" src="https://user-images.githubusercontent.com/368013/47959459-01a2bc00-e039-11e8-908c-85a14e8477f8.png">
A radix tree with only static routes was 2.3 times slower than the hash.

I also removed the call to `.upcase` when parsing the request as the HTTP standard specifies that this should be case sensitive - as such all browsers will make the request in the required case already.
