### PR TITLE
add crystal v1 support

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,7 @@
 name: router
-version: 0.2.7
+version: 0.2.8
+
+crystal: 1.0.0
 
 authors:
   - Taichiro Suzuki <taichiro0709@gmail.com>


### PR DESCRIPTION
Hi @tbrand,

This `PR` add support for version **1**.

The manifest `shard.yml` need to have a version property, the one given here means that we can compile any app using `router.cr` in **crystal** 1.x

Regards,

PS : I also upgrade version, since this is only a patch